### PR TITLE
Replace custom excerpt helper with wp_trim_words

### DIFF
--- a/archive.php
+++ b/archive.php
@@ -24,7 +24,7 @@ $term = get_queried_object();
                                         role="article">
                                     <span class="date"><?php echo get_the_time('d.m.y')?></span>
                                     <h3><a href="<?php the_permalink(); ?>"><?php the_title() ?></a></h3>
-                                    <p><?php echo excerpt(15); ?></p>
+                                    <p><?php echo wp_trim_words(get_the_excerpt(), 15, '...'); ?></p>
                                     <a class="more" href="<?php the_permalink(); ?>"><i
                                                 class="ion-ios-arrow-thin-left"></i></a>
                                 </article>

--- a/functions.php
+++ b/functions.php
@@ -165,22 +165,6 @@ add_filter( 'the_excerpt', 'div_wrapper' );
 add_filter( 'gform_enable_field_label_visibility_settings', '__return_true' );
 
 /* ---------------------------------------------------------------------------
- * 11. פונקציית excerpt מותאמת
- * --------------------------------------------------------------------------- */
-function excerpt($limit) {
-    $excerpt = explode(' ', get_the_excerpt(), $limit);
-    if (count($excerpt) >= $limit) {
-        array_pop($excerpt);
-        $excerpt = implode(" ",$excerpt).'...';
-    } else {
-        $excerpt = implode(" ",$excerpt);
-    }
-    // הסרה של Shortcodes (סינון נוסף לסניטציה/אבטחה לפי צורך)
-    $excerpt = preg_replace('`[[^]]*]`','',$excerpt);
-    return $excerpt;
-}
-
-/* ---------------------------------------------------------------------------
  * 12. תמיכה בהעלאת SVG (הוספה ל-MIME Types)
  * --------------------------------------------------------------------------- */
 function cc_mime_types($mimes) {

--- a/index.php
+++ b/index.php
@@ -25,7 +25,7 @@ $term = get_queried_object();
                                 role="article">
                             <span class="date"><?php echo get_the_time('d.m.y')?></span>
                             <h3><a href="<?php the_permalink(); ?>"><?php the_title() ?></a></h3>
-                            <p><?php echo excerpt(15); ?></p>
+                            <p><?php echo wp_trim_words(get_the_excerpt(), 15, '...'); ?></p>
                             <a class="more" href="<?php the_permalink(); ?>"><i
                                         class="ion-ios-arrow-thin-left"></i></a>
 

--- a/post-formats/article.php
+++ b/post-formats/article.php
@@ -32,12 +32,7 @@
 					</div>
 					<div class="text-holder">
 						<a href="<?php the_permalink(); ?>"><?php the_title('<h3>','</h3>'); ?>	</a>
-						<?php
-						$excerpt = get_the_excerpt();
-						$excerpt = substr($excerpt, 0, 260);
-						$result = substr($excerpt, 0, strrpos($excerpt, ' '));
-						echo '<p>' . $result . '...</p>';
-						?>
+                                                <p><?php echo wp_trim_words(get_the_excerpt(), 40, '...'); ?></p>
 					</div>
 						
 					

--- a/single-lawyers.php
+++ b/single-lawyers.php
@@ -64,7 +64,7 @@ get_header();
                                                     id="post-<?php the_ID(); ?>" <?php post_class(); ?>
                                                     role="article">
                                                 <h3><a href="<?php the_permalink(); ?>"><?php the_title() ?></a></h3>
-                                                <p><?php echo excerpt(8); ?></p>
+                                                <p><?php echo wp_trim_words(get_the_excerpt(), 8, '...'); ?></p>
                                                 <a class="more" href="<?php the_permalink(); ?>"><i
                                                             class="ion-ios-arrow-back"></i></a>
                                             </article>

--- a/template-parts/article-box.php
+++ b/template-parts/article-box.php
@@ -8,7 +8,7 @@
     }?>
     <div class="caption">
         <h3><a href="<?php the_permalink()?>"><?php the_title()?></a></h3>
-        <p><?php echo excerpt(15)?></p>
+        <p><?php echo wp_trim_words(get_the_excerpt(), 15, '...'); ?></p>
     </div>
     <a class="readmore" href="<?php the_permalink()?>"><i class="icon ion-ios-arrow-back"></i></a>
 </article>

--- a/template-parts/article-mini-box.php
+++ b/template-parts/article-mini-box.php
@@ -3,7 +3,7 @@
       <?php the_post_thumbnail('article-thumb');?>
     <div class="caption">
         <h3><a href="<?php the_permalink()?>"><?php the_title()?></a></h3>
-        <p><?php echo excerpt(8)?></p>
+        <p><?php echo wp_trim_words(get_the_excerpt(), 8, '...'); ?></p>
     </div>
     <a class="readmore" href="<?php the_permalink()?>"><i class="icon ion-ios-arrow-back"></i></a>
 </article>


### PR DESCRIPTION
## Summary
- remove bespoke `excerpt` helper
- use `wp_trim_words` with explicit word limits and custom ellipsis across templates

## Testing
- `php -l functions.php`
- `php -l single-lawyers.php`
- `php -l archive.php`
- `php -l index.php`
- `php -l template-parts/article-mini-box.php`
- `php -l template-parts/article-box.php`
- `php -l post-formats/article.php`


------
https://chatgpt.com/codex/tasks/task_e_689f004eacf483239614e35aa2e93385