### PR TITLE
Define and escape side banner link

### DIFF
--- a/sidebar-articles.php
+++ b/sidebar-articles.php
@@ -163,12 +163,13 @@
         </div>
     <?php endif;  ?>
    
-    <?php $side_banner= get_field('side_banner', 'option');
+    <?php $side_banner = get_field('side_banner', 'option');
+    $side_banner_link = get_field('side_banner_link', 'option');
     if($side_banner):
     ?>
 
     <div class="widget banner">
-        <a href="<?= $side_banner_link['url'] ?>">
+        <a href="<?= esc_url( $side_banner_link['url'] ) ?>">
             <img src="<?php echo $side_banner['url']; ?>" alt="<?php echo $side_banner['alt']; ?>"/>
         </a>
     </div>


### PR DESCRIPTION
## Summary
- Define `side_banner_link` using `get_field` in sidebar banner
- Escape banner link URL with `esc_url`

## Testing
- `php -l sidebar-articles.php`


------
https://chatgpt.com/codex/tasks/task_e_689f00504e548323a467c5c782816e2e