### PR TITLE
Fix sidebar recent articles query order and reset

### DIFF
--- a/sidebar-articles.php
+++ b/sidebar-articles.php
@@ -15,7 +15,7 @@
 <?php
     $recent_articles = new WP_Query(array(
         'post_type' => 'articles',
-        'orderby' => 'post_parent__in',
+        'orderby' => 'post__in',
         'order' => 'relevance',
         'posts_per_page' =>5,
     ));
@@ -24,12 +24,14 @@
         <div class="widget articles">
             <h4 class="widgettitle">המלצות</h4>
             <ul>
-				<?php
-				while ($recent_articles->have_posts()) : $recent_articles->the_post();
-				get_template_part('template-parts/article-mini-box');
-				endwhile; ?>
-			</ul>
-	</div>
+                                <?php
+                                while ($recent_articles->have_posts()) : $recent_articles->the_post();
+                                get_template_part('template-parts/article-mini-box');
+                                endwhile;
+                                wp_reset_postdata();
+                                ?>
+                        </ul>
+        </div>
 	<div class="widget">
 		<h4 class="widgettitle">צרו קשר</h4>
 		<?php echo do_shortcode('[gravityform id=1 title=false description=true ajax=true]'); ?>


### PR DESCRIPTION
## Summary
- replace invalid `post_parent__in` orderby with `post__in`
- reset post data after custom query loop

## Testing
- `php -l sidebar-articles.php`


------
https://chatgpt.com/codex/tasks/task_e_689f0051524c8323b63b6900e71cde3b