### PR TITLE
Add shortcode and search filter checks

### DIFF
--- a/template-parts/search-bar.php
+++ b/template-parts/search-bar.php
@@ -1,12 +1,14 @@
 <div class="search-bar">
     <div class="container">
-        <?php echo do_shortcode('[searchandfilter id="335"]');?>
+        <?php if ( shortcode_exists( 'searchandfilter' ) ) : ?>
+            <?= do_shortcode( '[searchandfilter id="335"]' ); ?>
+        <?php endif; ?>
     </div>
     <?php
-    //Get an array of objects containing data for the current search/filter
-    //replace `1526` with the ID of your search form
     global $searchandfilter;
-    $sf_current_query = $searchandfilter->get(335)->current_query();
-    echo $sf_current_query->get_search_term();
+    if ( isset( $searchandfilter ) ) {
+        $sf_current_query = $searchandfilter->get( 335 )->current_query();
+        echo $sf_current_query->get_search_term();
+    }
     ?>
 </div>


### PR DESCRIPTION
## Summary
- ensure search-and-filter shortcode exists before rendering
- guard search filter global before accessing query

## Testing
- `php -l template-parts/search-bar.php`
- `composer validate --no-check-publish`


------
https://chatgpt.com/codex/tasks/task_e_689f4028529c8323a59ce1f2cd8dac34