### PR TITLE
Guard get_field usage

### DIFF
--- a/footer.php
+++ b/footer.php
@@ -5,12 +5,12 @@
             <div class="row">
                 <div id="footer-about" class="col-md-4">
                     <h3 class="widget-title">מי אנחנו</h3>
-                    <p><?= get_field('footer_about', 'option'); ?></p>
+                    <p><?= function_exists('get_field') ? get_field('footer_about', 'option') : '' ?></p>
                     <a class="readmore" href="<?php echo get_page_link(28); ?>">קראו עוד עלינו<i class="aero-arrow-left-thin"></i></a>
                 </div>
                 <div id="footer-site-info" class="col-md-4">
                     <h3 class="widget-title">פרטי התקשרות</h3>
-                    <p><strong>כתובת</strong><span><?php echo get_field('site_address1', 'option'); ?></span></p>
+                    <p><strong>כתובת</strong><span><?php echo function_exists('get_field') ? get_field('site_address1', 'option') : '' ?></span></p>
                     <p><strong>טלפון</strong><span><?php get_template_part('template-parts/site-phone'); ?></span></p>
                     <p><strong>אימייל</strong><span><?php get_template_part('template-parts/site-email'); ?></span></p>
                 </div>

--- a/functions.php
+++ b/functions.php
@@ -182,10 +182,10 @@ function my_wp_nav_menu_objects( $items, $args ) {
     // וידוא שה-Menu location הוא main-nav
     if( $args->theme_location === 'main-nav' ) {
         foreach( $items as &$item ) {
-            $icon = get_field('menu_icon', $item);
+            $icon = function_exists('get_field') ? get_field('menu_icon', $item) : '';
             if( $icon ) {
                 // סניטציה לאובייקט התמונה
-                $icon_url = esc_url( $icon['url'] );
+                $icon_url = esc_url( $icon['url'] ?? '' );
                 $item->title = '<img src="'. $icon_url .'" alt="" /> ' . $item->title;
             }
         }

--- a/header.php
+++ b/header.php
@@ -53,7 +53,7 @@
                 <div class="container">
                     <div class="d-sm-flex justify-content-end align-items-center">
                        <!--ul class="contact-details d-none d-md-flex">
-                           <li><?php echo get_field('site_address1', 'option'); ?></li>
+                           <li><?php echo function_exists('get_field') ? get_field('site_address1', 'option') : '' ?></li>
                            <li><?php get_template_part('template-parts/site-email'); ?></li>
                            <li><?php get_template_part('template-parts/site-phone'); ?></li>
                        </ul-->
@@ -65,11 +65,9 @@
                 <div class="d-flex justify-content-sm-between flex-column-reverse d-sm-row flex-sm-row">
                     <?php
                     $site_logo_url = '';
-                    if (function_exists('get_field')) {
-                        $logo_field = get_field('site_logo', 'option');
-                        if (!empty($logo_field['url'])) {
-                            $site_logo_url = $logo_field['url'];
-                        }
+                    $logo_field = function_exists('get_field') ? get_field('site_logo', 'option') : '';
+                    if (!empty($logo_field['url'])) {
+                        $site_logo_url = $logo_field['url'];
                     }
                     if (!$site_logo_url) {
                         $site_logo_url = get_template_directory_uri() . '/library/images/logo.png';
@@ -135,8 +133,8 @@
                         endif; ?>
                   
 				     </h1>
-					                    <?php if (get_field('subtitle')) {
-                        echo '<p class="subtitle">' . get_field('subtitle') . '</p>';
+<?php if (function_exists('get_field') && get_field('subtitle')) {
+                        echo '<p class="subtitle">' . (function_exists('get_field') ? get_field('subtitle') : '') . '</p>';
                     } ?>
 															
                     <?php if (is_home()) echo '<p class="subtitle">עורכי הדין המומלצים </p>'; ?>

--- a/page-contact.php
+++ b/page-contact.php
@@ -5,7 +5,7 @@
 
 get_header();
 ?>
-<?php $content_width  = get_field('content_width');?>
+<?php $content_width = function_exists('get_field') ? get_field('content_width') : '';?>
     <div id="primary" class="content-area">
         <main id="main" class="site-main  narrow has-bg <?php echo $content_width ?>" role="main">
 

--- a/page-home.php
+++ b/page-home.php
@@ -11,9 +11,9 @@ get_header(); ?>
         if (have_rows('home_features')): ?>
             <section id="home-features" class="no-padding clearfix">
                 <div class="container">
-                    <?php if(get_field('home_features_title')):?>
+                    <?php if (function_exists('get_field') && get_field('home_features_title')):?>
                     <div class="section-title">
-                        <h2><?= get_field('home_features_title')?></h2>
+                        <h2><?= function_exists('get_field') ? get_field('home_features_title') : ''?></h2>
                     </div>
                     <?php endif;?>
                 </div>
@@ -58,8 +58,8 @@ get_header(); ?>
             <div class="container">
                 <div class="row">
                     <div class="col-auto col-lg-6 caption">
-                        <?php if (get_field('about_title')){?>
-                        <h2 class="title"><?= get_field('about_title')?></h2>
+                        <?php if (function_exists('get_field') && get_field('about_title')){?>
+                        <h2 class="title"><?= function_exists('get_field') ? get_field('about_title') : ''?></h2>
                         <?php }?>
                         <div class="desc">
                             <?php the_content() ?>
@@ -73,7 +73,7 @@ get_header(); ?>
                             </div>
                             <div class="embed-responsive embed-responsive-16by9">
                                 <iframe id="video" width="560" height="315"
-                                        src="https://www.youtube-nocookie.com/embed/<?= get_field('about_video')?>?rel=0" frameborder="0"
+                                        src="https://www.youtube-nocookie.com/embed/<?= function_exists('get_field') ? get_field('about_video') : ''?>?rel=0" frameborder="0"
                                         allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture"
                                         allowfullscreen></iframe>
                             </div>
@@ -90,7 +90,7 @@ get_header(); ?>
                 </div>
 				
 				<?php 
-				$article_category = get_field('article_category', 'option');
+                                $article_category = function_exists('get_field') ? get_field('article_category', 'option') : '';
 				//echo "<pre>"; print_r($article_category); echo "</pre>";
 				?>
 				
@@ -168,24 +168,24 @@ get_header(); ?>
 
             </div>
         </section>
-        <?php  $feat_terms = get_field('lawyer_cats');
+        <?php  $feat_terms = function_exists('get_field') ? get_field('lawyer_cats') : '';
          if ( $feat_terms) : ?>
              <section id="law-cats">
                 <div class="container">
                     <div class="section-title">
-                        <h2><?= get_field('categories_title')?></h2>
+                        <h2><?= function_exists('get_field') ? get_field('categories_title') : ''?></h2>
                     </div>
                 </div>
                 <div class="container wide">
                     <div class="row">
                       <?php foreach($feat_terms as $term ):
 
-                            $cat_image = get_field('cat_icon',$term);
+                            $cat_image = function_exists('get_field') ? get_field('cat_icon',$term) : '';
                             ?>
                           <div class="col-auto item">
                             <div class="cat-box">
                                 <div class="caption">
-                                    <img src="<?php echo $cat_image['url']?>"/>
+                                    <img src="<?php echo $cat_image['url'] ?? ''?>"/>
                                     <h3><?php echo $term->name; ?></h3>
                                     <p><?php echo $term->description; ?></p>
                                 </div>
@@ -200,7 +200,7 @@ get_header(); ?>
         <section id="lawyers">
             <div class="container">
                 <div class="section-title accent">
-                    <h2><?= get_field('featured_lawyers_title') ?></h2>
+                    <h2><?= function_exists('get_field') ? get_field('featured_lawyers_title') : '' ?></h2>
                 </div>
 
                 <ul class="nav nav-tabs  d-flex" role="tablist">

--- a/page-tools.php
+++ b/page-tools.php
@@ -4,7 +4,7 @@
 */
 
 get_header(); ?>
-<?php $content_width = get_field('content_width'); ?>
+<?php $content_width = function_exists('get_field') ? get_field('content_width') : ''; ?>
 <div id="primary" class="content-area">
     <main id="main" class="site-main  has-bg <?php echo $content_width ?>" role="main">
 

--- a/page.php
+++ b/page.php
@@ -1,5 +1,5 @@
 <?php get_header(); ?>
-<?php $content_width  = get_field('content_width');?>
+<?php $content_width = function_exists('get_field') ? get_field('content_width') : '';?>
 <div id="primary" class="content-area">
     <main id="main" class="site-main <?php echo $content_width ?>" role="main">
         <div class="container">

--- a/post-formats/article.php
+++ b/post-formats/article.php
@@ -12,13 +12,13 @@
     </section>
 
     <footer class="article-footer">
-		<?php if(get_field('show_extra')):?>
+                <?php if (function_exists('get_field') && get_field('show_extra')):?>
 		<div class="related-posts-wrapper">
 			<h2>
 				לכתבות נוספות
 			</h2>
 			<?php
-			$featured_posts = get_field('related_posts');
+                        $featured_posts = function_exists('get_field') ? get_field('related_posts') : '';
 			if( $featured_posts ): ?>
 			<div class="inner-wrapper">
 				<?php foreach( $featured_posts as $post ): 

--- a/sidebar-articles.php
+++ b/sidebar-articles.php
@@ -165,14 +165,14 @@
         </div>
     <?php endif;  ?>
    
-    <?php $side_banner = get_field('side_banner', 'option');
-    $side_banner_link = get_field('side_banner_link', 'option');
+    <?php $side_banner = function_exists('get_field') ? get_field('side_banner', 'option') : '';
+    $side_banner_link = function_exists('get_field') ? get_field('side_banner_link', 'option') : '';
     if($side_banner):
     ?>
 
     <div class="widget banner">
-        <a href="<?= esc_url( $side_banner_link['url'] ) ?>">
-            <img src="<?php echo $side_banner['url']; ?>" alt="<?php echo $side_banner['alt']; ?>"/>
+        <a href="<?= esc_url( $side_banner_link['url'] ?? '' ) ?>">
+            <img src="<?php echo $side_banner['url'] ?? ''; ?>" alt="<?php echo $side_banner['alt'] ?? ''; ?>"/>
         </a>
     </div>
     <?php endif;?>

--- a/single-lawyers.php
+++ b/single-lawyers.php
@@ -17,13 +17,13 @@ get_header();
                         <header class="lawyer-header">
                             <h2 class="title small"><?php the_title(); ?></h2>
                             <?php
-                            $phone = get_field('profile_phone');
-                            $whatsapp = get_field('profile_whatsapp');
-                            $facebook = get_field('profile_facebook');
-                            $linkedin = get_field('profile_linkedin');
-                            $twitter = get_field('profile_twitter');
-                            $availability = get_field('availability');
-                            $iframe = get_field('profile_video');
+                            $phone = function_exists('get_field') ? get_field('profile_phone') : '';
+                            $whatsapp = function_exists('get_field') ? get_field('profile_whatsapp') : '';
+                            $facebook = function_exists('get_field') ? get_field('profile_facebook') : '';
+                            $linkedin = function_exists('get_field') ? get_field('profile_linkedin') : '';
+                            $twitter = function_exists('get_field') ? get_field('profile_twitter') : '';
+                            $availability = function_exists('get_field') ? get_field('availability') : '';
+                            $iframe = function_exists('get_field') ? get_field('profile_video') : '';
                             if ($phone) { ?>
                                 <div class="phone d-flex align-items-center">
                                     <a class="tel" href="tel:<?php echo $phone ?>"><?php echo $phone ?></a>
@@ -52,7 +52,7 @@ get_header();
                             <div class="row">
 
                                 <?php
-                                $post_objects = get_field('profile_articles');
+                                $post_objects = function_exists('get_field') ? get_field('profile_articles') : '';
                                 if ($post_objects): ?>
                                     <div class="col-auto col-md-6 related">
                                         <div class="section-title small">

--- a/template-parts/site-email.php
+++ b/template-parts/site-email.php
@@ -1,3 +1,3 @@
-<?php $site_email = get_field('site_email', 'option'); ?>
+<?php $site_email = function_exists('get_field') ? get_field('site_email', 'option') : ''; ?>
 
 <a href="mailto:<?php echo $site_email; ?>" class="site-email"><?php echo $site_email; ?></a>

--- a/template-parts/site-phone.php
+++ b/template-parts/site-phone.php
@@ -1,3 +1,3 @@
-<?php $site_phone = get_field('site_phone1', 'option'); ?>
+<?php $site_phone = function_exists('get_field') ? get_field('site_phone1', 'option') : ''; ?>
 
 <a href="tel:<?php echo $site_phone; ?>" class="site-phone"><?php echo $site_phone; ?></a>


### PR DESCRIPTION
## Summary
- wrap ACF get_field calls in function_exists checks with empty string fallbacks
- guard image field indices with null coalescing

## Testing
- `php -l page.php page-home.php functions.php footer.php post-formats/article.php page-contact.php template-parts/site-email.php template-parts/site-phone.php single-lawyers.php header.php sidebar-articles.php page-tools.php`


------
https://chatgpt.com/codex/tasks/task_e_689f40206618832397addf174ea45936