### PR TITLE
Add card thumbnail styling and wrappers

### DIFF
--- a/library/css/theme.css
+++ b/library/css/theme.css
@@ -2288,4 +2288,8 @@ header {
   display: block;
 }
 
+.card__thumb img{width:100%;height:100%;object-fit:cover;aspect-ratio:4/3;}
+.btn,[role="button"]{cursor:pointer;}
+.sr-only{position:absolute;width:1px;height:1px;overflow:hidden;clip:rect(1px,1px,1px,1px);white-space:nowrap;}
+
 /*# sourceMappingURL=theme.css.map */

--- a/template-parts/article-box.php
+++ b/template-parts/article-box.php
@@ -1,11 +1,13 @@
 <article id="post-<?php the_ID(); ?>" <?php post_class('col-sm-6 item d-flex'); ?>
          role="article">
-    <?php if(has_post_thumbnail()){
-        the_post_thumbnail('article-thumb');
-    } else{?>
-        <img src="<?php echo get_template_directory_uri() ?>/library/images/article_thumb.jpg"/>
-    <?php
-    }?>
+    <div class="card__thumb">
+        <?php if(has_post_thumbnail()){
+            the_post_thumbnail('article-thumb');
+        } else{?>
+            <img src="<?php echo get_template_directory_uri() ?>/library/images/article_thumb.jpg"/>
+        <?php
+        }?>
+    </div>
     <div class="caption">
         <h3><a href="<?php the_permalink()?>"><?php the_title()?></a></h3>
         <p><?php echo wp_trim_words(get_the_excerpt(), 15, '...'); ?></p>

--- a/template-parts/article-mini-box.php
+++ b/template-parts/article-mini-box.php
@@ -1,6 +1,8 @@
 <article id="post-<?php the_ID(); ?>" <?php post_class('item d-flex'); ?>
          role="article">
-      <?php the_post_thumbnail('article-thumb');?>
+    <div class="card__thumb">
+        <?php the_post_thumbnail('article-thumb');?>
+    </div>
     <div class="caption">
         <h3><a href="<?php the_permalink()?>"><?php the_title()?></a></h3>
         <p><?php echo wp_trim_words(get_the_excerpt(), 8, '...'); ?></p>

--- a/template-parts/lawyer-box.php
+++ b/template-parts/lawyer-box.php
@@ -1,8 +1,9 @@
 <article id="post-<?php the_ID(); ?>" <?php post_class('col-auto col-md-4'); ?>
          role="article">
     <div class="lawyer-card">
+        <div class="card__thumb">
             <?php the_post_thumbnail('profile-thumb') ?>
-
+        </div>
         <div class="caption">
             <h3><a href="<?php the_permalink() ?>"><?php the_title() ?></a></h3>
             <p class="meta"><?php echo get_the_term_list(get_the_ID(), 'lawyer-cat', '<span>', '</span>, <span>', '</span>') ?></p>


### PR DESCRIPTION
## Summary
- style `.card__thumb` images and add utility classes for buttons and screen-reader text
- wrap card thumbnails in `card__thumb` containers for article and lawyer templates

## Testing
- `php -l template-parts/article-box.php template-parts/article-mini-box.php template-parts/lawyer-box.php`
- `composer validate`


------
https://chatgpt.com/codex/tasks/task_e_689f401e8128832391afe9e7ab3d4031