### PR TITLE
Add lawyer card block and register lawyer metadata

### DIFF
--- a/blocks/lawyer-card/block.json
+++ b/blocks/lawyer-card/block.json
@@ -1,0 +1,13 @@
+{
+  "apiVersion": 2,
+  "name": "aero/lawyer-card",
+  "title": "Lawyer Card",
+  "category": "widgets",
+  "icon": "id",
+  "description": "Displays a lawyer card.",
+  "supports": { "html": false },
+  "attributes": {
+    "lawyerId": { "type": "integer", "default": 0 }
+  },
+  "editorScript": "file:./index.js"
+}

--- a/blocks/lawyer-card/index.asset.php
+++ b/blocks/lawyer-card/index.asset.php
@@ -1,0 +1,4 @@
+<?php return [
+    'dependencies' => ['wp-blocks', 'wp-element', 'wp-components', 'wp-data', 'wp-i18n'],
+    'version' => '1.0.0'
+];

--- a/blocks/lawyer-card/index.js
+++ b/blocks/lawyer-card/index.js
@@ -1,0 +1,29 @@
+const { registerBlockType } = wp.blocks;
+const { __ } = wp.i18n;
+const { useSelect } = wp.data;
+const { SelectControl } = wp.components;
+const { createElement: el } = wp.element;
+
+registerBlockType('aero/lawyer-card', {
+    title: __('Lawyer Card', 'aero'),
+    icon: 'id',
+    category: 'widgets',
+    attributes: { lawyerId: { type: 'number', default: 0 } },
+    edit: ({ attributes, setAttributes }) => {
+        const lawyers = useSelect(select => select('core').getEntityRecords('postType', 'lawyers', { per_page: -1 }), []);
+        if (!lawyers) {
+            return el('p', {}, __('Loading...', 'aero'));
+        }
+        const options = [{ label: __('Select a lawyer', 'aero'), value: 0 }];
+        lawyers.forEach(lawyer => {
+            options.push({ label: lawyer.title.rendered, value: lawyer.id });
+        });
+        return el(SelectControl, {
+            label: __('Lawyer', 'aero'),
+            value: attributes.lawyerId,
+            options,
+            onChange: value => setAttributes({ lawyerId: parseInt(value, 10) })
+        });
+    },
+    save: () => null,
+});

--- a/functions.php
+++ b/functions.php
@@ -19,6 +19,8 @@ require_once get_template_directory() . '/library/bones.php';                 //
 
 require_once get_template_directory() . '/inc/acf-compatibility.php';
 require_once get_template_directory() . '/inc/helpers.php';
+require_once get_template_directory() . '/inc/custom-post-types.php';
+require_once get_template_directory() . '/inc/blocks-loader.php';
 /* ---------------------------------------------------------------------------
  * 2. הפעלת התבנית (after_setup_theme)
  * --------------------------------------------------------------------------- */

--- a/inc/blocks-lawyer-card.php
+++ b/inc/blocks-lawyer-card.php
@@ -1,0 +1,40 @@
+<?php
+function aero_render_lawyer_card($attributes = []) {
+    $lawyer_id = isset($attributes['lawyerId']) ? intval($attributes['lawyerId']) : 0;
+    if (!$lawyer_id) {
+        return '';
+    }
+    $post = get_post($lawyer_id);
+    if (!$post) {
+        return '';
+    }
+    $permalink = get_permalink($post);
+    $title = get_the_title($post);
+    $thumb = get_the_post_thumbnail($post, 'profile-thumb');
+    $terms = get_the_term_list($lawyer_id, 'lawyer-cat', '<span>', '</span>, <span>', '</span>');
+    $phone = get_post_meta($lawyer_id, 'phone', true);
+    $email = get_post_meta($lawyer_id, 'email', true);
+    $website = get_post_meta($lawyer_id, 'website', true);
+    $linkedin = get_post_meta($lawyer_id, 'linkedin', true);
+    $office = get_post_meta($lawyer_id, 'office_location', true);
+    ob_start();
+    ?>
+    <article class="lawyer-card">
+        <?= $thumb ?>
+        <div class="caption">
+            <h3><a href="<?= esc_url($permalink) ?>"><?= esc_html($title) ?></a></h3>
+            <?php if ($terms) : ?>
+                <p class="meta"><?= $terms ?></p>
+            <?php endif; ?>
+            <ul class="contact">
+                <?php if ($phone) : ?><li><?= esc_html($phone) ?></li><?php endif; ?>
+                <?php if ($email) : ?><li><a href="mailto:<?= esc_attr($email) ?>"><?= esc_html($email) ?></a></li><?php endif; ?>
+                <?php if ($website) : ?><li><a href="<?= esc_url($website) ?>"><?= esc_html($website) ?></a></li><?php endif; ?>
+                <?php if ($linkedin) : ?><li><a href="<?= esc_url($linkedin) ?>"><?= esc_html($linkedin) ?></a></li><?php endif; ?>
+                <?php if ($office) : ?><li><?= esc_html($office) ?></li><?php endif; ?>
+            </ul>
+        </div>
+    </article>
+    <?php
+    return ob_get_clean();
+}

--- a/inc/blocks-loader.php
+++ b/inc/blocks-loader.php
@@ -1,0 +1,6 @@
+<?php
+add_action('init', function () {
+    register_block_type(__DIR__ . '/../blocks/lawyer-card', [
+        'render_callback' => 'aero_render_lawyer_card',
+    ]);
+});

--- a/inc/custom-post-types.php
+++ b/inc/custom-post-types.php
@@ -1,0 +1,12 @@
+<?php
+add_action('init', function () {
+    $lawyer_meta = ['phone', 'email', 'website', 'linkedin', 'office_location'];
+    foreach ($lawyer_meta as $key) {
+        register_post_meta('lawyers', $key, [
+            'type' => 'string',
+            'single' => true,
+            'show_in_rest' => true,
+            'sanitize_callback' => 'sanitize_text_field',
+        ]);
+    }
+});


### PR DESCRIPTION
## Summary
- register lawyer contact meta fields
- add server-rendered lawyer card block
- allow selecting lawyers in block editor

## Testing
- `php -l inc/custom-post-types.php inc/blocks-lawyer-card.php inc/blocks-loader.php functions.php`
- `node --check blocks/lawyer-card/index.js`

------
https://chatgpt.com/codex/tasks/task_e_689f401ae3f08323961dbbd0d95fe45e