### PR TITLE
Add block-based theme

### DIFF
--- a/wp-content/themes/justice-block/parts/footer.html
+++ b/wp-content/themes/justice-block/parts/footer.html
@@ -1,0 +1,3 @@
+<!-- wp:group -->
+<!-- wp:paragraph -->Thanks<!-- /wp:paragraph -->
+<!-- /wp:group -->

--- a/wp-content/themes/justice-block/parts/header.html
+++ b/wp-content/themes/justice-block/parts/header.html
@@ -1,0 +1,4 @@
+<!-- wp:group -->
+<!-- wp:site-title /-->
+<!-- wp:navigation /-->
+<!-- /wp:group -->

--- a/wp-content/themes/justice-block/templates/index.html
+++ b/wp-content/themes/justice-block/templates/index.html
@@ -1,0 +1,6 @@
+<!-- wp:template-part {"slug":"header"} /-->
+<!-- wp:group -->
+<!-- wp:post-title /-->
+<!-- wp:post-content /-->
+<!-- /wp:group -->
+<!-- wp:template-part {"slug":"footer"} /-->

--- a/wp-content/themes/justice-block/theme.json
+++ b/wp-content/themes/justice-block/theme.json
@@ -1,0 +1,13 @@
+{
+  "version": 2,
+  "settings": {
+    "layout": {
+      "contentSize": "650px",
+      "wideSize": "1000px"
+    }
+  },
+  "templateParts": [
+    { "name": "header", "title": "Header" },
+    { "name": "footer", "title": "Footer" }
+  ]
+}


### PR DESCRIPTION
## Summary
- add block theme folder justice-block
- define layout and template parts in theme.json
- implement index template with header and footer parts

## Testing
- `python -m json.tool wp-content/themes/justice-block/theme.json`
- `tidy -qe wp-content/themes/justice-block/templates/index.html` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a9f68834488323b3b03e1a829b5ff2