### PR TITLE
Add SEO AIO mu-plugin

### DIFF
--- a/wp-content/mu-plugins/seo-aio.php
+++ b/wp-content/mu-plugins/seo-aio.php
@@ -1,0 +1,14 @@
+<?php
+/*
+Plugin Name: SEO AIO
+Description: Loads tasks, REST routes, and helpers.
+*/
+if (defined('ABSPATH')) {
+    $dir = __DIR__ . '/seo-aio';
+    foreach (['tasks.php','rest.php','helpers.php'] as $part) {
+        $file = $dir . '/' . $part;
+        if (is_file($file)) {
+            include $file;
+        }
+    }
+}

--- a/wp-content/mu-plugins/seo-aio/helpers.php
+++ b/wp-content/mu-plugins/seo-aio/helpers.php
@@ -1,0 +1,7 @@
+<?php
+if (!function_exists('seo_aio_format')) {
+    function seo_aio_format($text) {
+        $text = trim($text);
+        return sanitize_text_field($text);
+    }
+}

--- a/wp-content/mu-plugins/seo-aio/rest.php
+++ b/wp-content/mu-plugins/seo-aio/rest.php
@@ -1,0 +1,11 @@
+<?php
+if (function_exists('add_action')) {
+    add_action('rest_api_init', function() {
+        register_rest_route('seo-aio/v1', '/count', [
+            'methods' => 'GET',
+            'callback' => function() {
+                return ['count' => get_option('seo_aio_count', 0)];
+            }
+        ]);
+    });
+}

--- a/wp-content/mu-plugins/seo-aio/tasks.php
+++ b/wp-content/mu-plugins/seo-aio/tasks.php
@@ -1,0 +1,10 @@
+<?php
+if (function_exists('add_action')) {
+    if (!wp_next_scheduled('seo_aio_daily')) {
+        wp_schedule_event(time(), 'daily', 'seo_aio_daily');
+    }
+    add_action('seo_aio_daily', function() {
+        $count = get_option('seo_aio_count', 0);
+        update_option('seo_aio_count', $count + 1);
+    });
+}


### PR DESCRIPTION
## Summary
- add must-use plugin to load SEO helpers
- provide scheduled task and REST route modules
- include helper function for text formatting

## Testing
- `php -l wp-content/mu-plugins/seo-aio.php`
- `php -l wp-content/mu-plugins/seo-aio/tasks.php`
- `php -l wp-content/mu-plugins/seo-aio/rest.php`
- `php -l wp-content/mu-plugins/seo-aio/helpers.php`


------
https://chatgpt.com/codex/tasks/task_e_68a9f68d999c83238e9a9e9737928e4b