### PR TITLE
Filter singular document titles and add meta tags

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -304,3 +304,35 @@ function category_trail_shortcode() {
     return $output;
 }
 add_shortcode( 'category-trail', 'category_trail_shortcode' );
+
+function aero_index_document_title($title) {
+    if (is_singular()) {
+        $title = get_the_title(get_queried_object_id());
+    }
+    return $title;
+}
+add_filter('pre_get_document_title','aero_index_document_title');
+
+function aero_index_meta_tags() {
+    if (is_singular()) {
+        $post_obj = get_queried_object();
+        $description = '';
+        if ($post_obj) {
+            $description = wp_strip_all_tags(get_the_excerpt($post_obj));
+        }
+        $description = esc_attr($description);
+        $title = esc_attr(get_the_title($post_obj));
+        $url = esc_url(get_permalink($post_obj));
+        $site = esc_attr(get_bloginfo('name'));
+        echo '<meta name="description" content="' . $description . '">';
+        echo '<meta property="og:title" content="' . $title . '">';
+        echo '<meta property="og:description" content="' . $description . '">';
+        echo '<meta property="og:url" content="' . $url . '">';
+        echo '<meta property="og:site_name" content="' . $site . '">';
+        $image = get_the_post_thumbnail_url($post_obj, 'full');
+        if ($image) {
+            echo '<meta property="og:image" content="' . esc_url($image) . '">';
+        }
+    }
+}
+add_action('wp_head','aero_index_meta_tags');


### PR DESCRIPTION
## Summary
- Filter document title on singular views
- Emit meta description and Open Graph tags in wp_head

## Testing
- `php -l functions.php`
- `composer validate`


------
https://chatgpt.com/codex/tasks/task_e_68a9f6a4e0e883238ade6ea2f8dcff07